### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,24 +54,23 @@
     "postcss-loader": "^1.0.0",
     "precss": "^1.4.0",
     "react-addons-test-utils": "15.3.2",
-    "react-dom": "15.1.0",
+    "react-dom": "15.3.2",
     "react-hot-loader": "3.0.0-beta.6",
     "style-loader": "0.13.1",
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.2",
-    "react-dom": "15.3.2",
     "node-sass": "^3.10.1",
     "sass-loader": "^4.0.2"
   },
   "dependencies": {
     "babel-cli": "6.16.0",
     "classnames": "^2.2.5",
-    "node-uuid": "1.4.7",
     "react": "15.3.2",
     "react-addons-css-transition-group": "15.3.2",
     "react-addons-shallow-compare": "15.3.2",
     "react-redux": "4.4.5",
     "react-themeable": "^1.1.0",
-    "redux": "3.6.0"
+    "redux": "3.6.0",
+    "uuid": "^3.0.0"
   }
 }

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import {connect} from 'react-redux';
 import Items from './components/items';
 import {actionCreators} from './reducerAndActions';

--- a/src/reducerAndActions.js
+++ b/src/reducerAndActions.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 
 export const NOTIFY = '@@react-yell/NOTIFY';
 export const CLOSE_NOTIFICATION = '@@react-yell/CLOSE_NOTIFICATION';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.